### PR TITLE
Fix Citrea RPC transactionIndex incompatibility

### DIFF
--- a/citrea-transport-fix.ts
+++ b/citrea-transport-fix.ts
@@ -1,0 +1,54 @@
+import { http, type Transport, type TransportConfig } from "viem";
+
+/**
+ * Ultra-minimal fix for Citrea's transactionIndex bug.
+ * Wraps HTTP transport to correct transactionIndex in eth_getLogs responses.
+ *
+ * This is the most efficient solution - fixes data in-memory without any proxy overhead.
+ */
+export function citreaTransport(url: string): Transport {
+  const baseTransport = http(url);
+
+  return (config: TransportConfig) => {
+    const transport = baseTransport(config);
+    const originalRequest = transport.request;
+
+    // Return a new transport object to avoid mutating the original
+    return {
+      ...transport,
+      request: async (args: any) => {
+        const response = await originalRequest(args);
+
+        // Only process eth_getLogs responses
+        if (args.method === 'eth_getLogs' && Array.isArray(response)) {
+          // Cache to avoid duplicate block fetches
+          const blockCache = new Map<string, any>();
+
+          for (const log of response) {
+            if (!log.blockNumber || !log.transactionHash) continue;
+
+            // Fetch block if not cached
+            let block = blockCache.get(log.blockNumber);
+            if (!block) {
+              block = await originalRequest({
+                method: 'eth_getBlockByNumber',
+                params: [log.blockNumber, true]
+              });
+              blockCache.set(log.blockNumber, block);
+            }
+
+            // Find correct transaction index by hash
+            const txs = block?.transactions ?? [];
+            const idx = txs.findIndex((tx: any) => tx?.hash === log.transactionHash);
+            if (idx >= 0) {
+              // Convert to hex to match expected format
+              log.transactionIndex = `0x${idx.toString(16)}`;
+            }
+          }
+        }
+
+        return response;
+      }
+    };
+  };
+}

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -1,12 +1,13 @@
 import { createConfig } from "ponder";
 import { UniswapV3PoolAbi } from "./abis/UniswapV3Pool";
+import { citreaTransport } from "./citrea-transport-fix";
 
 export default createConfig({
   chains: {
     // Citrea Testnet
     citreaTestnet: {
       id: 5115,
-      rpc: "http://localhost:8545",
+      rpc: citreaTransport(process.env.CITREA_RPC_URL ?? "https://rpc.testnet.citrea.xyz"),
     },
   },
   contracts: {


### PR DESCRIPTION
## Summary
- Implements custom transport to fix Citrea Testnet RPC transactionIndex issues
- Resolves transaction hash mismatch problems preventing Ponder sync

## Changes
- Add `citrea-transport-fix.ts` with efficient in-memory correction of transactionIndex values
- Update `ponder.config.ts` to use custom transport with environment variable support
- Switch from localhost proxy to direct RPC with intelligent correction layer

## Technical Details
The custom transport intercepts `eth_getLogs` responses and corrects invalid transactionIndex values by:
1. Caching block data to avoid redundant requests
2. Finding correct transaction index by matching transaction hashes
3. Converting indices to proper hex format

This resolves the fundamental data integrity issues documented in `CITREA_RPC_ISSUES.md` without requiring external proxy servers.

## Test Plan
- [ ] Verify Ponder can sync from Citrea Testnet without errors
- [ ] Test with different startBlock values
- [ ] Confirm transaction indices match actual block transaction positions