### PR TITLE
Fix YAML syntax in production workflow (#25)

### DIFF
--- a/.github/workflows/ci-prd.yml
+++ b/.github/workflows/ci-prd.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
-      inputs:
+    inputs:
       reset_schema:
         description: 'Create new schema version (resets database)'
         required: false


### PR DESCRIPTION
Corrected missing colon after 'inputs' in workflow_dispatch configuration to enable reset_schema option in GitHub Actions UI