### PR TITLE
Add sync status endpoint for monitoring

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -448,7 +448,7 @@ app.get("/api/sync-status", async (c: Context) => {
       });
 
       if (response.ok) {
-        const data = await response.json();
+        const data = await response.json() as { result?: string };
         if (data.result) {
           // Convert hex to decimal
           currentChainBlock = parseInt(data.result, 16);


### PR DESCRIPTION
## Summary
- Added new `/api/sync-status` endpoint for monitoring Ponder indexer synchronization
- Provides real-time sync percentage and indexing statistics

## Changes
- Fetch current chain block height from Citrea RPC
- Calculate precise sync percentage (indexed blocks / chain blocks)
- Show blocks behind current chain head
- Include statistics for swaps, pools, and positions

## Endpoint Response
```json
{
  "status": "OK",
  "timestamp": "2024-09-26T...",
  "sync": {
    "latestIndexedBlock": 1485230,
    "currentChainBlock": 1485245,
    "blocksBehind": 15,
    "syncPercentage": 99.99,
    "status": "syncing"
  },
  "stats": {
    "swaps": 1523,
    "pools": 3,
    "positions": 245
  }
}
```

## Testing
Access the endpoint at `/api/sync-status` to monitor indexing progress.