### PR TITLE
Fix: Proper Azure deployment using container scaling

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -84,28 +84,32 @@ jobs:
         with:
           creds: ${{ secrets.DFX_DEV_CREDENTIALS }}
 
-      - name: Stop existing container before deployment
+      - name: Scale down container to prevent conflicts
         uses: azure/CLI@v2
         with:
           inlineScript: |
-            echo "Stopping existing container app to prevent conflicts..."
-            az containerapp stop --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} || echo "Container was not running"
-            echo "Waiting 10 seconds for complete shutdown..."
-            sleep 10
+            echo "Scaling down container app to 0 replicas..."
+            az containerapp update \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --name ${{ env.AZURE_CONTAINER_APP }} \
+              --min-replicas 0 \
+              --max-replicas 0 || echo "Failed to scale down, continuing anyway"
+            echo "Waiting 15 seconds for complete shutdown..."
+            sleep 15
 
       - name: Update Azure Container App with new image
         uses: azure/CLI@v2
         with:
           inlineScript: |
-            echo "Updating container app with new image..."
-            az containerapp update --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} --image ${{ env.DOCKER_TAGS }} --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}${{ inputs.reset_schema == true && format(' PONDER_SCHEMA_VERSION={0}', github.run_number) || '' }}
-
-      - name: Start container app
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            echo "Starting container app..."
-            az containerapp start --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }}
+            echo "Updating container app with new image and scaling back up..."
+            az containerapp update \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --name ${{ env.AZURE_CONTAINER_APP }} \
+              --image ${{ env.DOCKER_TAGS }} \
+              --min-replicas 1 \
+              --max-replicas 1 \
+              --revision-mode single \
+              --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}${{ inputs.reset_schema == true && format(' PONDER_SCHEMA_VERSION={0}', github.run_number) || '' }}
             echo "Deployment completed successfully!"
 
       - name: Logout from Azure

--- a/.github/workflows/ci-prd.yml
+++ b/.github/workflows/ci-prd.yml
@@ -83,28 +83,32 @@ jobs:
         with:
           creds: ${{ secrets.DFX_PRD_CREDENTIALS }}
 
-      - name: Stop existing container before deployment
+      - name: Scale down container to prevent conflicts
         uses: azure/CLI@v2
         with:
           inlineScript: |
-            echo "Stopping existing container app to prevent conflicts..."
-            az containerapp stop --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} || echo "Container was not running"
-            echo "Waiting 10 seconds for complete shutdown..."
-            sleep 10
+            echo "Scaling down container app to 0 replicas..."
+            az containerapp update \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --name ${{ env.AZURE_CONTAINER_APP }} \
+              --min-replicas 0 \
+              --max-replicas 0 || echo "Failed to scale down, continuing anyway"
+            echo "Waiting 15 seconds for complete shutdown..."
+            sleep 15
 
       - name: Update Azure Container App with new image
         uses: azure/CLI@v2
         with:
           inlineScript: |
-            echo "Updating container app with new image..."
-            az containerapp update --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} --image ${{ env.DOCKER_TAGS }} --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}${{ inputs.reset_schema == true && format(' PONDER_SCHEMA_VERSION={0}', github.run_number) || '' }}
-
-      - name: Start container app
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            echo "Starting container app..."
-            az containerapp start --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }}
+            echo "Updating container app with new image and scaling back up..."
+            az containerapp update \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --name ${{ env.AZURE_CONTAINER_APP }} \
+              --image ${{ env.DOCKER_TAGS }} \
+              --min-replicas 1 \
+              --max-replicas 1 \
+              --revision-mode single \
+              --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}${{ inputs.reset_schema == true && format(' PONDER_SCHEMA_VERSION={0}', github.run_number) || '' }}
             echo "Deployment completed successfully!"
 
       - name: Logout from Azure


### PR DESCRIPTION
## Problem
The previous PR #34 used `az containerapp start/stop` commands which **don't exist** in Azure CLI, causing deployment failures.

## Root Cause
Azure Container Apps don't have start/stop commands like VMs. They use scaling and revision management instead.

## Solution
Implement proper deployment sequence using valid Azure CLI commands:

1. **Scale down** to 0 replicas: `--min-replicas 0 --max-replicas 0`
2. **Wait** 15 seconds for clean shutdown
3. **Update and scale up** in single command:
   - New image
   - Scale back to 1 replica
   - Force single revision mode

## Key Changes
- Replace non-existent `start/stop` with proper scaling commands
- Use `--revision-mode single` to prevent multiple instances
- Combine update and scale-up in one command for efficiency

## Benefits
- ✅ Uses valid Azure CLI commands
- ✅ Prevents container overlap
- ✅ Avoids PGlite database conflicts  
- ✅ Clean deployment process

## Testing
This will be tested in DEV environment first before production deployment.