### PR TITLE
Fix: Use proper Azure Container Apps scaling instead of non-existent …

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -108,7 +108,7 @@ jobs:
               --image ${{ env.DOCKER_TAGS }} \
               --min-replicas 1 \
               --max-replicas 1 \
-              --revision-mode single \
+              --revisions-mode single \
               --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}${{ inputs.reset_schema == true && format(' PONDER_SCHEMA_VERSION={0}', github.run_number) || '' }}
             echo "Deployment completed successfully!"
 

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -108,7 +108,6 @@ jobs:
               --image ${{ env.DOCKER_TAGS }} \
               --min-replicas 1 \
               --max-replicas 1 \
-              --revisions-mode single \
               --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}${{ inputs.reset_schema == true && format(' PONDER_SCHEMA_VERSION={0}', github.run_number) || '' }}
             echo "Deployment completed successfully!"
 

--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -84,28 +84,32 @@ jobs:
         with:
           creds: ${{ secrets.DFX_DEV_CREDENTIALS }}
 
-      - name: Stop existing container before deployment
+      - name: Scale down container to prevent conflicts
         uses: azure/CLI@v2
         with:
           inlineScript: |
-            echo "Stopping existing container app to prevent conflicts..."
-            az containerapp stop --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} || echo "Container was not running"
-            echo "Waiting 10 seconds for complete shutdown..."
-            sleep 10
+            echo "Scaling down container app to 0 replicas..."
+            az containerapp update \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --name ${{ env.AZURE_CONTAINER_APP }} \
+              --min-replicas 0 \
+              --max-replicas 0 || echo "Failed to scale down, continuing anyway"
+            echo "Waiting 15 seconds for complete shutdown..."
+            sleep 15
 
       - name: Update Azure Container App with new image
         uses: azure/CLI@v2
         with:
           inlineScript: |
-            echo "Updating container app with new image..."
-            az containerapp update --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} --image ${{ env.DOCKER_TAGS }} --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}${{ inputs.reset_schema == true && format(' PONDER_SCHEMA_VERSION={0}', github.run_number) || '' }}
-
-      - name: Start container app
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            echo "Starting container app..."
-            az containerapp start --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }}
+            echo "Updating container app with new image and scaling back up..."
+            az containerapp update \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --name ${{ env.AZURE_CONTAINER_APP }} \
+              --image ${{ env.DOCKER_TAGS }} \
+              --min-replicas 1 \
+              --max-replicas 1 \
+              --revision-mode single \
+              --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}${{ inputs.reset_schema == true && format(' PONDER_SCHEMA_VERSION={0}', github.run_number) || '' }}
             echo "Deployment completed successfully!"
 
       - name: Logout from Azure

--- a/.github/workflows/ci-prd.yml
+++ b/.github/workflows/ci-prd.yml
@@ -107,7 +107,6 @@ jobs:
               --image ${{ env.DOCKER_TAGS }} \
               --min-replicas 1 \
               --max-replicas 1 \
-              --revisions-mode single \
               --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}${{ inputs.reset_schema == true && format(' PONDER_SCHEMA_VERSION={0}', github.run_number) || '' }}
             echo "Deployment completed successfully!"
 

--- a/.github/workflows/ci-prd.yml
+++ b/.github/workflows/ci-prd.yml
@@ -83,28 +83,32 @@ jobs:
         with:
           creds: ${{ secrets.DFX_PRD_CREDENTIALS }}
 
-      - name: Stop existing container before deployment
+      - name: Scale down container to prevent conflicts
         uses: azure/CLI@v2
         with:
           inlineScript: |
-            echo "Stopping existing container app to prevent conflicts..."
-            az containerapp stop --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} || echo "Container was not running"
-            echo "Waiting 10 seconds for complete shutdown..."
-            sleep 10
+            echo "Scaling down container app to 0 replicas..."
+            az containerapp update \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --name ${{ env.AZURE_CONTAINER_APP }} \
+              --min-replicas 0 \
+              --max-replicas 0 || echo "Failed to scale down, continuing anyway"
+            echo "Waiting 15 seconds for complete shutdown..."
+            sleep 15
 
       - name: Update Azure Container App with new image
         uses: azure/CLI@v2
         with:
           inlineScript: |
-            echo "Updating container app with new image..."
-            az containerapp update --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }} --image ${{ env.DOCKER_TAGS }} --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}${{ inputs.reset_schema == true && format(' PONDER_SCHEMA_VERSION={0}', github.run_number) || '' }}
-
-      - name: Start container app
-        uses: azure/CLI@v2
-        with:
-          inlineScript: |
-            echo "Starting container app..."
-            az containerapp start --resource-group ${{ env.AZURE_RESOURCE_GROUP }} --name ${{ env.AZURE_CONTAINER_APP }}
+            echo "Updating container app with new image and scaling back up..."
+            az containerapp update \
+              --resource-group ${{ env.AZURE_RESOURCE_GROUP }} \
+              --name ${{ env.AZURE_CONTAINER_APP }} \
+              --image ${{ env.DOCKER_TAGS }} \
+              --min-replicas 1 \
+              --max-replicas 1 \
+              --revision-mode single \
+              --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}${{ inputs.reset_schema == true && format(' PONDER_SCHEMA_VERSION={0}', github.run_number) || '' }}
             echo "Deployment completed successfully!"
 
       - name: Logout from Azure

--- a/.github/workflows/ci-prd.yml
+++ b/.github/workflows/ci-prd.yml
@@ -107,7 +107,7 @@ jobs:
               --image ${{ env.DOCKER_TAGS }} \
               --min-replicas 1 \
               --max-replicas 1 \
-              --revision-mode single \
+              --revisions-mode single \
               --set-env-vars DEPLOY_INFO=${{ env.DEPLOY_INFO }}${{ inputs.reset_schema == true && format(' PONDER_SCHEMA_VERSION={0}', github.run_number) || '' }}
             echo "Deployment completed successfully!"
 


### PR DESCRIPTION
…start/stop commands (#35)

Problem:
- az containerapp start/stop commands don't exist
- Previous solution caused deployment failures

Solution:
- Scale down to 0 replicas before deployment
- Update image and scale back up to 1 replica in single command
- Force single revision mode to prevent multiple instances
- 15 second wait for clean shutdown

This ensures:
- No overlapping containers
- Clean deployment process
- Prevents PGlite database conflicts
- Valid Azure CLI commands only