### PR TITLE
Fix sync percentage calculation

### DIFF
--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -468,7 +468,7 @@ app.get("/api/sync-status", async (c: Context) => {
         latestIndexedBlock,
         currentChainBlock,
         blocksBehind,
-        syncPercentage: Number(syncPercentage.toFixed(2)),
+        syncPercentage: `${syncPercentage.toFixed(2)}%`,
         status: isSynced ? "synced" : "syncing"
       },
       stats: {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -468,7 +468,7 @@ app.get("/api/sync-status", async (c: Context) => {
         latestIndexedBlock,
         currentChainBlock,
         blocksBehind,
-        syncPercentage: `${syncPercentage.toFixed(2)}%`,
+        syncPercentage: Number(syncPercentage.toFixed(2)),
         status: isSynced ? "synced" : "syncing"
       },
       stats: {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -393,6 +393,9 @@ app.get("/api/sync-status", async (c: Context) => {
     let poolCount = 0;
     let positionCount = 0;
 
+    // Define the start block from ponder.config.ts
+    const START_BLOCK = 15455001;
+
     // Get latest indexed block and counts from database
     try {
       // Get latest swap block number
@@ -448,9 +451,11 @@ app.get("/api/sync-status", async (c: Context) => {
       currentChainBlock = Math.max(latestIndexedBlock + 1000, 1500000);
     }
 
-    // Calculate precise sync percentage
-    const syncPercentage = (latestIndexedBlock > 0 && currentChainBlock > 0)
-      ? Math.min(100, (latestIndexedBlock / currentChainBlock) * 100)
+    // Calculate precise sync percentage based on actual progress from start block
+    const blocksProcessed = Math.max(0, latestIndexedBlock - START_BLOCK);
+    const totalBlocksToProcess = Math.max(1, currentChainBlock - START_BLOCK);
+    const syncPercentage = (latestIndexedBlock > 0 && currentChainBlock > START_BLOCK)
+      ? Math.min(100, (blocksProcessed / totalBlocksToProcess) * 100)
       : 0;
 
     const blocksBehind = Math.max(0, currentChainBlock - latestIndexedBlock);


### PR DESCRIPTION
## Summary
- Fixed sync percentage calculation to show actual progress from configured start block (15455001)
- Now shows accurate sync progress (e.g., 99.81% instead of 99.99%)
- Displays percentage with 2 decimal places as numeric value

## Changes
- Calculate sync percentage based on blocks processed since start block
- Formula: `(latestIndexedBlock - START_BLOCK) / (currentChainBlock - START_BLOCK) * 100`
- More accurate representation of indexing progress

## Testing
- Tested locally: shows 100.00 when fully synced
- Previously showed 99.99% even when only 1-10 blocks behind