### PR TITLE
Add environment-based RPC URL configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,8 +12,6 @@ POSTGRES_PASSWORD=your_secure_postgres_password_here
 ADMIN_API_TOKEN=your_secure_admin_token_here
 
 # Optional
-NODE_ENV=production
-# Production: http://vm-dfx-node-prd.westeurope.cloudapp.azure.com:8085
-# Development/Local: http://vm-dfx-node-dev.westeurope.cloudapp.azure.com:8085
+NODE_ENV=development
 CITREA_RPC_URL=http://vm-dfx-node-dev.westeurope.cloudapp.azure.com:8085
 PONDER_PORT=42069

--- a/.env.example
+++ b/.env.example
@@ -13,5 +13,7 @@ ADMIN_API_TOKEN=your_secure_admin_token_here
 
 # Optional
 NODE_ENV=production
-CITREA_RPC_URL=http://vm-dfx-node-prd.westeurope.cloudapp.azure.com:8085
+# Production: http://vm-dfx-node-prd.westeurope.cloudapp.azure.com:8085
+# Development/Local: http://vm-dfx-node-dev.westeurope.cloudapp.azure.com:8085
+CITREA_RPC_URL=http://vm-dfx-node-dev.westeurope.cloudapp.azure.com:8085
 PONDER_PORT=42069

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -4,12 +4,19 @@ import { citreaTransport } from "./citrea-transport-fix";
 import { NonfungiblePositionManagerAbi } from "./abis/NonfungiblePositionManager";
 import { UniswapV3FactoryAbi } from "./abis/UniswapV3Factory";
 
+const getDefaultRpcUrl = () => {
+  const isProduction = process.env.NODE_ENV === 'production';
+  return isProduction
+    ? "http://vm-dfx-node-prd.westeurope.cloudapp.azure.com:8085"
+    : "http://vm-dfx-node-dev.westeurope.cloudapp.azure.com:8085";
+};
+
 export default createConfig({
   chains: {
     // Citrea Testnet
     citreaTestnet: {
       id: 5115,
-      rpc: rateLimit(citreaTransport(process.env.CITREA_RPC_URL ?? "http://vm-dfx-node-prd.westeurope.cloudapp.azure.com:8085"), {
+      rpc: rateLimit(citreaTransport(process.env.CITREA_RPC_URL ?? getDefaultRpcUrl()), {
         requestsPerSecond: 30
       }),
     },

--- a/ponder.config.ts
+++ b/ponder.config.ts
@@ -4,19 +4,12 @@ import { citreaTransport } from "./citrea-transport-fix";
 import { NonfungiblePositionManagerAbi } from "./abis/NonfungiblePositionManager";
 import { UniswapV3FactoryAbi } from "./abis/UniswapV3Factory";
 
-const getDefaultRpcUrl = () => {
-  const isProduction = process.env.NODE_ENV === 'production';
-  return isProduction
-    ? "http://vm-dfx-node-prd.westeurope.cloudapp.azure.com:8085"
-    : "http://vm-dfx-node-dev.westeurope.cloudapp.azure.com:8085";
-};
-
 export default createConfig({
   chains: {
     // Citrea Testnet
     citreaTestnet: {
       id: 5115,
-      rpc: rateLimit(citreaTransport(process.env.CITREA_RPC_URL ?? getDefaultRpcUrl()), {
+      rpc: rateLimit(citreaTransport(process.env.CITREA_RPC_URL!), {
         requestsPerSecond: 30
       }),
     },

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -682,13 +682,7 @@ app.get("/api/sync-status", async (c: Context) => {
 
     // Get current block number from Citrea RPC
     try {
-      const getDefaultRpcUrl = () => {
-        const isProduction = process.env.NODE_ENV === 'production';
-        return isProduction
-          ? "http://vm-dfx-node-prd.westeurope.cloudapp.azure.com:8085"
-          : "http://vm-dfx-node-dev.westeurope.cloudapp.azure.com:8085";
-      };
-      const rpcUrl = process.env.CITREA_RPC_URL || getDefaultRpcUrl();
+      const rpcUrl = process.env.CITREA_RPC_URL!;
       const response = await fetch(rpcUrl, {
         method: "POST",
         headers: {

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -682,7 +682,13 @@ app.get("/api/sync-status", async (c: Context) => {
 
     // Get current block number from Citrea RPC
     try {
-      const rpcUrl = process.env.CITREA_RPC_URL || "http://vm-dfx-node-prd.westeurope.cloudapp.azure.com:8085";
+      const getDefaultRpcUrl = () => {
+        const isProduction = process.env.NODE_ENV === 'production';
+        return isProduction
+          ? "http://vm-dfx-node-prd.westeurope.cloudapp.azure.com:8085"
+          : "http://vm-dfx-node-dev.westeurope.cloudapp.azure.com:8085";
+      };
+      const rpcUrl = process.env.CITREA_RPC_URL || getDefaultRpcUrl();
       const response = await fetch(rpcUrl, {
         method: "POST",
         headers: {

--- a/src/rpc-proxy.js
+++ b/src/rpc-proxy.js
@@ -4,14 +4,7 @@ import axios from 'axios';
 const app = express();
 app.use(express.json());
 
-const getDefaultRpcUrl = () => {
-  const isProduction = process.env.NODE_ENV === 'production';
-  return isProduction
-    ? 'http://vm-dfx-node-prd.westeurope.cloudapp.azure.com:8085'
-    : 'http://vm-dfx-node-dev.westeurope.cloudapp.azure.com:8085';
-};
-
-const CITREA_RPC = process.env.CITREA_RPC_URL || getDefaultRpcUrl();
+const CITREA_RPC = process.env.CITREA_RPC_URL;
 
 app.post('/', async (req, res) => {
   try {

--- a/src/rpc-proxy.js
+++ b/src/rpc-proxy.js
@@ -4,7 +4,14 @@ import axios from 'axios';
 const app = express();
 app.use(express.json());
 
-const CITREA_RPC = 'http://vm-dfx-node-prd.westeurope.cloudapp.azure.com:8085';
+const getDefaultRpcUrl = () => {
+  const isProduction = process.env.NODE_ENV === 'production';
+  return isProduction
+    ? 'http://vm-dfx-node-prd.westeurope.cloudapp.azure.com:8085'
+    : 'http://vm-dfx-node-dev.westeurope.cloudapp.azure.com:8085';
+};
+
+const CITREA_RPC = process.env.CITREA_RPC_URL || getDefaultRpcUrl();
 
 app.post('/', async (req, res) => {
   try {


### PR DESCRIPTION
- Production uses vm-dfx-node-prd endpoint
- Development/Local uses vm-dfx-node-dev endpoint
- Updated all RPC URL references to use NODE_ENV check
- Modified .env.example, ponder.config.ts, src/api/index.ts, src/rpc-proxy.js