### PR TITLE
Use native ARM64 runner and add SSH deploy

### DIFF
--- a/.github/workflows/ci-dev.yml
+++ b/.github/workflows/ci-dev.yml
@@ -36,14 +36,13 @@ jobs:
         run: npm test
         continue-on-error: true  # Tests not yet implemented
 
-  build-and-push:
-    name: Build and Push Docker Image
-    runs-on: ubuntu-latest
+  build-and-deploy:
+    name: Build and deploy to DEV
+    runs-on: ubuntu-24.04-arm
     needs: test
     if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -53,11 +52,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -76,3 +70,18 @@ jobs:
           build-args: |
             COMMIT_HASH=${{ steps.sha.outputs.short }}
 
+      - name: Install cloudflared
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Deploy to DEV
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_DEV_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_DEV_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_DEV_HOST }}" \
+            ${{ secrets.DEPLOY_DEV_USER }}@${{ secrets.DEPLOY_DEV_HOST }} \
+            "jsw-ponder"

--- a/.github/workflows/ci-prd.yml
+++ b/.github/workflows/ci-prd.yml
@@ -5,7 +5,6 @@ on:
     branches: [main]
   workflow_dispatch:
 
-
 env:
   NODE_VERSION: '20'
   DOCKER_TAGS: dfxswiss/juiceswap-ponder:latest
@@ -35,13 +34,12 @@ jobs:
         run: npm test
         continue-on-error: true  # Tests not yet implemented
 
-  build-and-push:
-    name: Build and Push Docker Image
-    runs-on: ubuntu-latest
+  build-and-deploy:
+    name: Build and deploy to PRD
+    runs-on: ubuntu-24.04-arm
     needs: test
     permissions:
       contents: read
-      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -51,11 +49,6 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-        with:
-          platforms: arm64
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -75,3 +68,18 @@ jobs:
             COMMIT_HASH=${{ steps.sha.outputs.short }}
             NODE_ENV=production
 
+      - name: Install cloudflared
+        run: |
+          curl -fsSL https://github.com/cloudflare/cloudflared/releases/download/2025.4.0/cloudflared-linux-arm64 -o /usr/local/bin/cloudflared
+          chmod +x /usr/local/bin/cloudflared
+
+      - name: Deploy to PRD
+        run: |
+          mkdir -p ~/.ssh
+          echo "${{ secrets.DEPLOY_PRD_SSH_KEY }}" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          echo "${{ secrets.DEPLOY_PRD_SSH_KNOWN_HOSTS }}" > ~/.ssh/known_hosts
+          ssh -i ~/.ssh/deploy_key \
+            -o ProxyCommand="cloudflared access ssh --hostname ${{ secrets.DEPLOY_PRD_HOST }}" \
+            ${{ secrets.DEPLOY_PRD_USER }}@${{ secrets.DEPLOY_PRD_HOST }} \
+            "jsw-ponder"


### PR DESCRIPTION
## Summary
- Switch from `ubuntu-latest` + QEMU to `ubuntu-24.04-arm` (native ARM64)
- Remove QEMU setup (no longer needed)
- Add SSH deploy to dfxdev/dfxprd via cloudflared tunnel

## Test plan
- [ ] CI build succeeds on ARM64 runner
- [ ] Docker image is ARM64