### PR TITLE
feat(api): /points endpoints for Juice Points UI

### DIFF
--- a/src/api/controllers/points.ts
+++ b/src/api/controllers/points.ts
@@ -1,0 +1,234 @@
+/**
+ * Points API controller — endpoints powering the JuiceSwap "Juice Points" UI.
+ *
+ *   GET /points/:address          → PointsBreakdown for this wallet
+ *   GET /points/leaderboard       → Top 100 wallets ranked by total points
+ *
+ * Anti-exploit guarantees (server-side, browser cannot influence):
+ *   - Swap counts come from the `transactionSwap` table, which the indexer only
+ *     populates for the official JuiceSwap V2/V3 routers (router-address whitelist
+ *     enforced at indexer-handler level). Custom contracts emitting fake `Swap`
+ *     events cannot be counted.
+ *   - Reverted/uncled txs do not produce logs, so they cannot be counted.
+ *   - We exclude any swap whose blockNumber is within FINALITY_OFFSET of the
+ *     indexer's latest block (defence-in-depth against last-second reorgs).
+ *   - Per-address daily cap (MAX_SWAP_POINTS_PER_DAY) prevents micro-swap farming.
+ *
+ * Liquidity points are stubbed as 0 in this version — wiring time-weighted
+ * minimum balance (`MIN_LIQUIDITY_USD` over 24h windows in whitelisted pools)
+ * requires a per-day position-snapshot table that the indexer does not yet
+ * write. This is tracked separately; the response shape is final so the
+ * frontend will pick it up automatically once the snapshot indexer ships.
+ */
+
+import { eq, and, desc, count, sql, gte, lte } from "drizzle-orm";
+import { Context, Hono } from "hono";
+import { isAddress } from "viem";
+import NodeCache from "node-cache";
+// @ts-ignore
+import { db } from "ponder:api";
+// @ts-ignore
+import { transactionSwap, blockProgress } from "ponder:schema";
+
+const POINTS_PER_SWAP = 100;
+const POINTS_PER_LIQUIDITY_DAY = 50;
+const MIN_LIQUIDITY_USD = 10;
+const MAX_SWAP_POINTS_PER_DAY = 1_000; // = 10 swaps per UTC day per address
+const FINALITY_OFFSET_BLOCKS = 32;
+const LEADERBOARD_LIMIT = 100;
+
+const POINTS_CACHE_TTL_S = 30;
+const LEADERBOARD_CACHE_TTL_S = 30;
+
+const pointsCache = new NodeCache({ stdTTL: POINTS_CACHE_TTL_S, checkperiod: 5, useClones: false });
+const leaderboardCache = new NodeCache({ stdTTL: LEADERBOARD_CACHE_TTL_S, checkperiod: 5, useClones: false });
+
+const SECONDS_PER_DAY = 86_400n;
+
+const points = new Hono();
+
+interface PointsBreakdown {
+  total: number;
+  swaps: { count: number; points: number };
+  liquidity: {
+    days: number;
+    points: number;
+    currentUsdValue: number;
+    meetsMinimum: boolean;
+  };
+}
+
+async function latestFinalizedBlock(): Promise<bigint | null> {
+  try {
+    const rows = await db.select().from(blockProgress).limit(1);
+    if (!rows.length) {
+      return null;
+    }
+    const latest = BigInt(rows[0].blockNumber);
+    return latest > BigInt(FINALITY_OFFSET_BLOCKS)
+      ? latest - BigInt(FINALITY_OFFSET_BLOCKS)
+      : 0n;
+  } catch (err) {
+    console.warn("blockProgress query failed", err);
+    return null;
+  }
+}
+
+/**
+ * Aggregate finalized swap points for an address with a per-day cap to deter
+ * micro-swap farming. Returns total swap points and underlying swap count.
+ */
+async function computeSwapPoints(
+  address: string,
+  finalityCutoff: bigint | null,
+): Promise<{ count: number; points: number }> {
+  const conditions = [
+    sql`LOWER(${transactionSwap.swapperAddress}) = LOWER(${address})`,
+  ];
+  if (finalityCutoff !== null) {
+    conditions.push(lte(transactionSwap.blockNumber, finalityCutoff));
+  }
+
+  // Pull just timestamp; aggregate per UTC day in JS (small dataset per wallet).
+  const rows = await db
+    .select({ ts: transactionSwap.blockTimestamp })
+    .from(transactionSwap)
+    .where(and(...conditions));
+
+  if (!rows.length) {
+    return { count: 0, points: 0 };
+  }
+
+  const perDay = new Map<string, number>();
+  for (const row of rows) {
+    const dayKey = String(BigInt(row.ts) / SECONDS_PER_DAY);
+    perDay.set(dayKey, (perDay.get(dayKey) ?? 0) + 1);
+  }
+
+  let totalPoints = 0;
+  for (const dayCount of perDay.values()) {
+    totalPoints += Math.min(dayCount * POINTS_PER_SWAP, MAX_SWAP_POINTS_PER_DAY);
+  }
+  return { count: rows.length, points: totalPoints };
+}
+
+/**
+ * Liquidity points scaffold. Returns zeros until the per-day position-snapshot
+ * indexer is in place — see file header for what's required to ship this.
+ */
+function liquidityPointsStub(): {
+  days: number;
+  points: number;
+  currentUsdValue: number;
+  meetsMinimum: boolean;
+} {
+  return {
+    days: 0,
+    points: 0,
+    currentUsdValue: 0,
+    meetsMinimum: false,
+  };
+}
+
+async function buildBreakdown(address: string): Promise<PointsBreakdown> {
+  const finalityCutoff = await latestFinalizedBlock();
+  const swaps = await computeSwapPoints(address, finalityCutoff);
+  const liquidity = liquidityPointsStub();
+  return {
+    total: swaps.points + liquidity.points,
+    swaps,
+    liquidity,
+  };
+}
+
+points.get("/leaderboard", async (c: Context) => {
+  const cached = leaderboardCache.get<{ entries: any[]; updatedAt: number }>("top");
+  if (cached) {
+    return c.json(cached);
+  }
+
+  try {
+    const finalityCutoff = await latestFinalizedBlock();
+    const conditions = [];
+    if (finalityCutoff !== null) {
+      conditions.push(lte(transactionSwap.blockNumber, finalityCutoff));
+    }
+
+    const rows = await db
+      .select({
+        address: sql<string>`LOWER(${transactionSwap.swapperAddress})`.as("addr"),
+        ts: transactionSwap.blockTimestamp,
+      })
+      .from(transactionSwap)
+      .where(conditions.length ? and(...conditions) : undefined);
+
+    const perAddress = new Map<string, number>();
+    const perAddressDays = new Map<string, Map<string, number>>();
+    for (const row of rows) {
+      const addr = row.address;
+      const dayKey = String(BigInt(row.ts) / SECONDS_PER_DAY);
+      let days = perAddressDays.get(addr);
+      if (!days) {
+        days = new Map();
+        perAddressDays.set(addr, days);
+      }
+      days.set(dayKey, (days.get(dayKey) ?? 0) + 1);
+    }
+    for (const [addr, days] of perAddressDays.entries()) {
+      let total = 0;
+      for (const dayCount of days.values()) {
+        total += Math.min(dayCount * POINTS_PER_SWAP, MAX_SWAP_POINTS_PER_DAY);
+      }
+      if (total > 0) {
+        perAddress.set(addr, total);
+      }
+    }
+
+    const sorted = [...perAddress.entries()].sort((a, b) => b[1] - a[1]).slice(0, LEADERBOARD_LIMIT);
+    const entries = sorted.map(([address, p], i) => ({
+      rank: i + 1,
+      address,
+      points: p,
+    }));
+    const payload = { entries, updatedAt: Date.now() };
+    leaderboardCache.set("top", payload);
+    return c.json(payload);
+  } catch (err) {
+    console.error("leaderboard error", err);
+    return c.json({ error: "Failed to compute leaderboard" }, 500);
+  }
+});
+
+points.get("/:address", async (c: Context) => {
+  const raw = c.req.param("address");
+  if (!raw || !isAddress(raw)) {
+    return c.json({ error: "Invalid address" }, 400);
+  }
+  const address = raw.toLowerCase();
+
+  const cached = pointsCache.get<PointsBreakdown>(address);
+  if (cached) {
+    return c.json(cached);
+  }
+
+  try {
+    const breakdown = await buildBreakdown(address);
+    pointsCache.set(address, breakdown);
+    return c.json(breakdown);
+  } catch (err) {
+    console.error("points error", err);
+    return c.json({ error: "Failed to compute points" }, 500);
+  }
+});
+
+export default points;
+
+// Surface configuration for documentation / sanity checks (read-only).
+export const POINTS_CONFIG = {
+  POINTS_PER_SWAP,
+  POINTS_PER_LIQUIDITY_DAY,
+  MIN_LIQUIDITY_USD,
+  MAX_SWAP_POINTS_PER_DAY,
+  FINALITY_OFFSET_BLOCKS,
+  LEADERBOARD_LIMIT,
+};

--- a/src/api/controllers/points.ts
+++ b/src/api/controllers/points.ts
@@ -1,8 +1,8 @@
 /**
- * Points API controller — endpoints powering the JuiceSwap "Juice Points" UI.
+ * Points API controller - endpoints powering the JuiceSwap "Juice Points" UI.
  *
- *   GET /points/:address          → PointsBreakdown for this wallet
- *   GET /points/leaderboard       → Top 100 wallets ranked by total points
+ *   GET /points/:address          -> PointsBreakdown for this wallet
+ *   GET /points/leaderboard       -> Top 100 wallets ranked by total points
  *
  * Anti-exploit guarantees (server-side, browser cannot influence):
  *   - Swap counts come from the `transactionSwap` table, which the indexer only
@@ -13,6 +13,8 @@
  *   - Any swap whose blockNumber is within FINALITY_OFFSET_BLOCKS of the
  *     indexer's latest block is excluded (defence-in-depth against last-second reorgs).
  *   - Per-address daily cap (MAX_SWAP_POINTS_PER_DAY) deters micro-swap farming.
+ *   - Fails closed: if `blockProgress` is unreadable we return 503 instead of
+ *     silently dropping the finality filter.
  *
  * Performance notes:
  *   - Aggregation is pushed into Postgres (CTE + GROUP BY + SUM(LEAST(...)))
@@ -23,7 +25,7 @@
  *   - Address comparison uses the checksum form (no LOWER(...) wrap) so the
  *     index is actually used.
  *
- * Liquidity points are stubbed as 0 in this version — wiring time-weighted
+ * Liquidity points are stubbed as 0 in this version - wiring time-weighted
  * minimum balance (`MIN_LIQUIDITY_USD` over 24h windows in whitelisted pools)
  * requires a per-day position-snapshot table that the indexer does not yet
  * write. This is tracked separately; the response shape is final so the
@@ -49,6 +51,17 @@ const LEADERBOARD_LIMIT = 100;
 const POINTS_CACHE_TTL_S = 30;
 const LEADERBOARD_CACHE_TTL_S = 30;
 
+interface LeaderboardEntry {
+  rank: number;
+  address: string;
+  points: number;
+}
+
+interface LeaderboardPayload {
+  entries: LeaderboardEntry[];
+  updatedAt: number;
+}
+
 const pointsCache = new NodeCache({ stdTTL: POINTS_CACHE_TTL_S, checkperiod: 5, useClones: false });
 const leaderboardCache = new NodeCache({ stdTTL: LEADERBOARD_CACHE_TTL_S, checkperiod: 5, useClones: false });
 
@@ -67,20 +80,28 @@ interface PointsBreakdown {
   };
 }
 
-async function latestFinalizedBlock(): Promise<bigint | null> {
-  try {
-    const rows = await db.select().from(blockProgress).limit(1);
-    if (!rows.length) {
-      return null;
-    }
-    const latest = BigInt(rows[0].blockNumber);
-    return latest > BigInt(FINALITY_OFFSET_BLOCKS)
-      ? latest - BigInt(FINALITY_OFFSET_BLOCKS)
-      : 0n;
-  } catch (err) {
-    console.warn("blockProgress query failed", err);
-    return null;
+class FinalityUnknownError extends Error {
+  constructor() {
+    super("blockProgress unavailable - cannot enforce finality cutoff");
+    this.name = "FinalityUnknownError";
   }
+}
+
+/**
+ * Returns the latest block we are willing to count points for, applying
+ * the finality buffer. Throws FinalityUnknownError if blockProgress cannot
+ * be read - callers should translate that into 503 so we never silently
+ * count unfinalized blocks.
+ */
+async function latestFinalizedBlock(): Promise<bigint> {
+  const rows = await db.select().from(blockProgress).limit(1);
+  if (!rows.length) {
+    throw new FinalityUnknownError();
+  }
+  const latest = BigInt(rows[0].blockNumber);
+  return latest > BigInt(FINALITY_OFFSET_BLOCKS)
+    ? latest - BigInt(FINALITY_OFFSET_BLOCKS)
+    : 0n;
 }
 
 function liquidityPointsStub(): PointsBreakdown["liquidity"] {
@@ -101,13 +122,8 @@ function liquidityPointsStub(): PointsBreakdown["liquidity"] {
  */
 async function computeSwapPoints(
   checksumAddress: string,
-  finalityCutoff: bigint | null,
+  finalityCutoff: bigint,
 ): Promise<{ count: number; points: number }> {
-  const conditions = [eq(transactionSwap.swapperAddress, checksumAddress)];
-  if (finalityCutoff !== null) {
-    conditions.push(lte(transactionSwap.blockNumber, finalityCutoff));
-  }
-
   const dayExpr = sql`floor(${transactionSwap.blockTimestamp} / ${SECONDS_PER_DAY})`;
 
   const dailyCounts = db.$with("daily_counts").as(
@@ -117,7 +133,12 @@ async function computeSwapPoints(
         n: count().as("n"),
       })
       .from(transactionSwap)
-      .where(and(...conditions))
+      .where(
+        and(
+          eq(transactionSwap.swapperAddress, checksumAddress),
+          lte(transactionSwap.blockNumber, finalityCutoff),
+        ),
+      )
       .groupBy(dayExpr),
   );
 
@@ -141,8 +162,10 @@ async function computeSwapPoints(
   };
 }
 
-async function buildBreakdown(checksumAddress: string): Promise<PointsBreakdown> {
-  const finalityCutoff = await latestFinalizedBlock();
+async function buildBreakdown(
+  checksumAddress: string,
+  finalityCutoff: bigint,
+): Promise<PointsBreakdown> {
   const swaps = await computeSwapPoints(checksumAddress, finalityCutoff);
   const liquidity = liquidityPointsStub();
   return {
@@ -153,18 +176,23 @@ async function buildBreakdown(checksumAddress: string): Promise<PointsBreakdown>
 }
 
 points.get("/leaderboard", async (c: Context) => {
-  const cached = leaderboardCache.get<{ entries: any[]; updatedAt: number }>("top");
+  const cached = leaderboardCache.get<LeaderboardPayload>("top");
   if (cached) {
     return c.json(cached);
   }
 
+  let finalityCutoff: bigint;
   try {
-    const finalityCutoff = await latestFinalizedBlock();
-    const baseConditions = [];
-    if (finalityCutoff !== null) {
-      baseConditions.push(lte(transactionSwap.blockNumber, finalityCutoff));
+    finalityCutoff = await latestFinalizedBlock();
+  } catch (err) {
+    if (err instanceof FinalityUnknownError) {
+      return c.json({ error: "Indexer not ready" }, 503);
     }
+    console.error("blockProgress query error", err);
+    return c.json({ error: "Failed to read indexer state" }, 500);
+  }
 
+  try {
     const dayExpr = sql`floor(${transactionSwap.blockTimestamp} / ${SECONDS_PER_DAY})`;
 
     // CTE 1: daily swap count per address.
@@ -176,7 +204,7 @@ points.get("/leaderboard", async (c: Context) => {
           n: count().as("n"),
         })
         .from(transactionSwap)
-        .where(baseConditions.length ? and(...baseConditions) : undefined)
+        .where(lte(transactionSwap.blockNumber, finalityCutoff))
         .groupBy(transactionSwap.swapperAddress, dayExpr),
     );
 
@@ -184,7 +212,7 @@ points.get("/leaderboard", async (c: Context) => {
     const pointsExpr =
       sql<string | number>`sum(least(${dailyCounts.n} * ${POINTS_PER_SWAP}, ${MAX_SWAP_POINTS_PER_DAY}))`;
 
-    const rows = await db
+    const rows: Array<{ addr: string; points: string | number }> = await db
       .with(dailyCounts)
       .select({
         addr: dailyCounts.addr,
@@ -195,12 +223,12 @@ points.get("/leaderboard", async (c: Context) => {
       .orderBy(desc(pointsExpr))
       .limit(LEADERBOARD_LIMIT);
 
-    const entries = rows.map((row: { addr: string; points: string | number }, i: number) => ({
+    const entries: LeaderboardEntry[] = rows.map((row, i) => ({
       rank: i + 1,
       address: String(row.addr).toLowerCase(),
       points: Number(row.points),
     }));
-    const payload = { entries, updatedAt: Date.now() };
+    const payload: LeaderboardPayload = { entries, updatedAt: Date.now() };
     leaderboardCache.set("top", payload);
     return c.json(payload);
   } catch (err) {
@@ -214,7 +242,7 @@ points.get("/:address", async (c: Context) => {
   if (!raw || !isAddress(raw)) {
     return c.json({ error: "Invalid address" }, 400);
   }
-  // Stored in checksum form by the indexer — preserve so the index is used.
+  // Stored in checksum form by the indexer - preserve so the index is used.
   const checksumAddress = getAddress(raw);
   const cacheKey = checksumAddress.toLowerCase();
 
@@ -223,8 +251,19 @@ points.get("/:address", async (c: Context) => {
     return c.json(cached);
   }
 
+  let finalityCutoff: bigint;
   try {
-    const breakdown = await buildBreakdown(checksumAddress);
+    finalityCutoff = await latestFinalizedBlock();
+  } catch (err) {
+    if (err instanceof FinalityUnknownError) {
+      return c.json({ error: "Indexer not ready" }, 503);
+    }
+    console.error("blockProgress query error", err);
+    return c.json({ error: "Failed to read indexer state" }, 500);
+  }
+
+  try {
+    const breakdown = await buildBreakdown(checksumAddress, finalityCutoff);
     pointsCache.set(cacheKey, breakdown);
     return c.json(breakdown);
   } catch (err) {

--- a/src/api/controllers/points.ts
+++ b/src/api/controllers/points.ts
@@ -10,9 +10,18 @@
  *     enforced at indexer-handler level). Custom contracts emitting fake `Swap`
  *     events cannot be counted.
  *   - Reverted/uncled txs do not produce logs, so they cannot be counted.
- *   - We exclude any swap whose blockNumber is within FINALITY_OFFSET of the
- *     indexer's latest block (defence-in-depth against last-second reorgs).
- *   - Per-address daily cap (MAX_SWAP_POINTS_PER_DAY) prevents micro-swap farming.
+ *   - Any swap whose blockNumber is within FINALITY_OFFSET_BLOCKS of the
+ *     indexer's latest block is excluded (defence-in-depth against last-second reorgs).
+ *   - Per-address daily cap (MAX_SWAP_POINTS_PER_DAY) deters micro-swap farming.
+ *
+ * Performance notes:
+ *   - Aggregation is pushed into Postgres (CTE + GROUP BY + SUM(LEAST(...)))
+ *     so the API never streams the full swap history into Node memory.
+ *   - Recommended composite index for fastest queries:
+ *       CREATE INDEX IF NOT EXISTS transaction_swap_swapper_block
+ *         ON "transactionSwap" ("swapperAddress", "blockNumber");
+ *   - Address comparison uses the checksum form (no LOWER(...) wrap) so the
+ *     index is actually used.
  *
  * Liquidity points are stubbed as 0 in this version — wiring time-weighted
  * minimum balance (`MIN_LIQUIDITY_USD` over 24h windows in whitelisted pools)
@@ -21,14 +30,14 @@
  * frontend will pick it up automatically once the snapshot indexer ships.
  */
 
-import { eq, and, desc, count, sql, gte, lte } from "drizzle-orm";
+import { and, count, desc, eq, lte, sql } from "drizzle-orm";
 import { Context, Hono } from "hono";
-import { isAddress } from "viem";
+import { getAddress, isAddress } from "viem";
 import NodeCache from "node-cache";
 // @ts-ignore
 import { db } from "ponder:api";
 // @ts-ignore
-import { transactionSwap, blockProgress } from "ponder:schema";
+import { blockProgress, transactionSwap } from "ponder:schema";
 
 const POINTS_PER_SWAP = 100;
 const POINTS_PER_LIQUIDITY_DAY = 50;
@@ -43,7 +52,7 @@ const LEADERBOARD_CACHE_TTL_S = 30;
 const pointsCache = new NodeCache({ stdTTL: POINTS_CACHE_TTL_S, checkperiod: 5, useClones: false });
 const leaderboardCache = new NodeCache({ stdTTL: LEADERBOARD_CACHE_TTL_S, checkperiod: 5, useClones: false });
 
-const SECONDS_PER_DAY = 86_400n;
+const SECONDS_PER_DAY = 86_400;
 
 const points = new Hono();
 
@@ -74,54 +83,7 @@ async function latestFinalizedBlock(): Promise<bigint | null> {
   }
 }
 
-/**
- * Aggregate finalized swap points for an address with a per-day cap to deter
- * micro-swap farming. Returns total swap points and underlying swap count.
- */
-async function computeSwapPoints(
-  address: string,
-  finalityCutoff: bigint | null,
-): Promise<{ count: number; points: number }> {
-  const conditions = [
-    sql`LOWER(${transactionSwap.swapperAddress}) = LOWER(${address})`,
-  ];
-  if (finalityCutoff !== null) {
-    conditions.push(lte(transactionSwap.blockNumber, finalityCutoff));
-  }
-
-  // Pull just timestamp; aggregate per UTC day in JS (small dataset per wallet).
-  const rows = await db
-    .select({ ts: transactionSwap.blockTimestamp })
-    .from(transactionSwap)
-    .where(and(...conditions));
-
-  if (!rows.length) {
-    return { count: 0, points: 0 };
-  }
-
-  const perDay = new Map<string, number>();
-  for (const row of rows) {
-    const dayKey = String(BigInt(row.ts) / SECONDS_PER_DAY);
-    perDay.set(dayKey, (perDay.get(dayKey) ?? 0) + 1);
-  }
-
-  let totalPoints = 0;
-  for (const dayCount of perDay.values()) {
-    totalPoints += Math.min(dayCount * POINTS_PER_SWAP, MAX_SWAP_POINTS_PER_DAY);
-  }
-  return { count: rows.length, points: totalPoints };
-}
-
-/**
- * Liquidity points scaffold. Returns zeros until the per-day position-snapshot
- * indexer is in place — see file header for what's required to ship this.
- */
-function liquidityPointsStub(): {
-  days: number;
-  points: number;
-  currentUsdValue: number;
-  meetsMinimum: boolean;
-} {
+function liquidityPointsStub(): PointsBreakdown["liquidity"] {
   return {
     days: 0,
     points: 0,
@@ -130,9 +92,58 @@ function liquidityPointsStub(): {
   };
 }
 
-async function buildBreakdown(address: string): Promise<PointsBreakdown> {
+/**
+ * One round-trip per-address aggregation:
+ *   - GROUP BY UTC day to apply MAX_SWAP_POINTS_PER_DAY cap server-side
+ *   - SUM the capped values to a single (swap_count, points) tuple
+ * Index lookup on (swapperAddress) keeps this O(matches) regardless of
+ * total transactionSwap row count.
+ */
+async function computeSwapPoints(
+  checksumAddress: string,
+  finalityCutoff: bigint | null,
+): Promise<{ count: number; points: number }> {
+  const conditions = [eq(transactionSwap.swapperAddress, checksumAddress)];
+  if (finalityCutoff !== null) {
+    conditions.push(lte(transactionSwap.blockNumber, finalityCutoff));
+  }
+
+  const dayExpr = sql`floor(${transactionSwap.blockTimestamp} / ${SECONDS_PER_DAY})`;
+
+  const dailyCounts = db.$with("daily_counts").as(
+    db
+      .select({
+        day: dayExpr.as("day"),
+        n: count().as("n"),
+      })
+      .from(transactionSwap)
+      .where(and(...conditions))
+      .groupBy(dayExpr),
+  );
+
+  const rows = await db
+    .with(dailyCounts)
+    .select({
+      swapCount: sql<string | number>`coalesce(sum(${dailyCounts.n}), 0)`.as(
+        "swap_count",
+      ),
+      points:
+        sql<string | number>`coalesce(sum(least(${dailyCounts.n} * ${POINTS_PER_SWAP}, ${MAX_SWAP_POINTS_PER_DAY})), 0)`.as(
+          "points",
+        ),
+    })
+    .from(dailyCounts);
+
+  const row = rows[0];
+  return {
+    count: Number(row?.swapCount ?? 0),
+    points: Number(row?.points ?? 0),
+  };
+}
+
+async function buildBreakdown(checksumAddress: string): Promise<PointsBreakdown> {
   const finalityCutoff = await latestFinalizedBlock();
-  const swaps = await computeSwapPoints(address, finalityCutoff);
+  const swaps = await computeSwapPoints(checksumAddress, finalityCutoff);
   const liquidity = liquidityPointsStub();
   return {
     total: swaps.points + liquidity.points,
@@ -149,46 +160,45 @@ points.get("/leaderboard", async (c: Context) => {
 
   try {
     const finalityCutoff = await latestFinalizedBlock();
-    const conditions = [];
+    const baseConditions = [];
     if (finalityCutoff !== null) {
-      conditions.push(lte(transactionSwap.blockNumber, finalityCutoff));
+      baseConditions.push(lte(transactionSwap.blockNumber, finalityCutoff));
     }
+
+    const dayExpr = sql`floor(${transactionSwap.blockTimestamp} / ${SECONDS_PER_DAY})`;
+
+    // CTE 1: daily swap count per address.
+    const dailyCounts = db.$with("daily_counts").as(
+      db
+        .select({
+          addr: transactionSwap.swapperAddress,
+          day: dayExpr.as("day"),
+          n: count().as("n"),
+        })
+        .from(transactionSwap)
+        .where(baseConditions.length ? and(...baseConditions) : undefined)
+        .groupBy(transactionSwap.swapperAddress, dayExpr),
+    );
+
+    // Outer: sum capped daily values per address, top N by points DESC.
+    const pointsExpr =
+      sql<string | number>`sum(least(${dailyCounts.n} * ${POINTS_PER_SWAP}, ${MAX_SWAP_POINTS_PER_DAY}))`;
 
     const rows = await db
+      .with(dailyCounts)
       .select({
-        address: sql<string>`LOWER(${transactionSwap.swapperAddress})`.as("addr"),
-        ts: transactionSwap.blockTimestamp,
+        addr: dailyCounts.addr,
+        points: pointsExpr.as("points"),
       })
-      .from(transactionSwap)
-      .where(conditions.length ? and(...conditions) : undefined);
+      .from(dailyCounts)
+      .groupBy(dailyCounts.addr)
+      .orderBy(desc(pointsExpr))
+      .limit(LEADERBOARD_LIMIT);
 
-    const perAddress = new Map<string, number>();
-    const perAddressDays = new Map<string, Map<string, number>>();
-    for (const row of rows) {
-      const addr = row.address;
-      const dayKey = String(BigInt(row.ts) / SECONDS_PER_DAY);
-      let days = perAddressDays.get(addr);
-      if (!days) {
-        days = new Map();
-        perAddressDays.set(addr, days);
-      }
-      days.set(dayKey, (days.get(dayKey) ?? 0) + 1);
-    }
-    for (const [addr, days] of perAddressDays.entries()) {
-      let total = 0;
-      for (const dayCount of days.values()) {
-        total += Math.min(dayCount * POINTS_PER_SWAP, MAX_SWAP_POINTS_PER_DAY);
-      }
-      if (total > 0) {
-        perAddress.set(addr, total);
-      }
-    }
-
-    const sorted = [...perAddress.entries()].sort((a, b) => b[1] - a[1]).slice(0, LEADERBOARD_LIMIT);
-    const entries = sorted.map(([address, p], i) => ({
+    const entries = rows.map((row: { addr: string; points: string | number }, i: number) => ({
       rank: i + 1,
-      address,
-      points: p,
+      address: String(row.addr).toLowerCase(),
+      points: Number(row.points),
     }));
     const payload = { entries, updatedAt: Date.now() };
     leaderboardCache.set("top", payload);
@@ -204,16 +214,18 @@ points.get("/:address", async (c: Context) => {
   if (!raw || !isAddress(raw)) {
     return c.json({ error: "Invalid address" }, 400);
   }
-  const address = raw.toLowerCase();
+  // Stored in checksum form by the indexer — preserve so the index is used.
+  const checksumAddress = getAddress(raw);
+  const cacheKey = checksumAddress.toLowerCase();
 
-  const cached = pointsCache.get<PointsBreakdown>(address);
+  const cached = pointsCache.get<PointsBreakdown>(cacheKey);
   if (cached) {
     return c.json(cached);
   }
 
   try {
-    const breakdown = await buildBreakdown(address);
-    pointsCache.set(address, breakdown);
+    const breakdown = await buildBreakdown(checksumAddress);
+    pointsCache.set(cacheKey, breakdown);
     return c.json(breakdown);
   } catch (err) {
     console.error("points error", err);

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -17,6 +17,7 @@ import launchpad from "./controllers/launchpad";
 import graduatedPools from "./controllers/graduatedPools";
 import activity from "./controllers/activity";
 import v2PoolStats from "./controllers/v2PoolStats";
+import points from "./controllers/points";
 import { blockProgress } from "ponder.schema";
 
 // Import middleware
@@ -60,6 +61,7 @@ app.route("/launchpad", launchpad);
 app.route("/graduated-pools", graduatedPools);
 app.route("/activity", activity);
 app.route("/v2-pool-stats", v2PoolStats);
+app.route("/points", points);
 
 // Info endpoint
 app.get("/api/info", async (c: Context) => {


### PR DESCRIPTION
## Summary

Adds `/points/{address}` and `/points/leaderboard` endpoints. Powers the Juice Points UI in the bapp frontend (companion PR: JuiceSwapxyz/bapp#TBD).

Server-side enforcement so the browser cannot influence point calculation.

## Anti-exploit guarantees

- **Router whitelist**: counts come from `transactionSwap` which the indexer only populates for the official V2/V3 routers. Fake `Swap` events from custom contracts are not counted.
- **Reverts excluded**: reverted/uncled txs do not produce logs and are therefore absent from the table.
- **Finality buffer**: blocks within `FINALITY_OFFSET_BLOCKS` (32) of the indexer's latest are excluded as defence-in-depth against last-second reorgs.
- **Daily cap**: `MAX_SWAP_POINTS_PER_DAY = 1000` (= 10 swaps/wallet/UTC day) deters micro-swap farming.
- **Cache**: 30s `NodeCache` on both endpoints.

## What's intentionally stubbed

Liquidity points (50 pts per 24h with ≥ \$10 USD in pools) return `0` for now. Shipping it cleanly requires a per-day position-snapshot table that the indexer doesn't yet write — tracking separately so points-per-swap can ship without blocking. The response shape is final, so the frontend will pick it up automatically once the snapshot indexer lands.

## Endpoints

```http
GET /points/leaderboard
{ entries: [{ rank, address, points }, ...], updatedAt }

GET /points/{address}
{
  total: number,
  swaps: { count, points },
  liquidity: { days, points, currentUsdValue, meetsMinimum }
}
```

## Test plan

- [ ] `GET /points/leaderboard` returns ≤ 100 sorted entries
- [ ] `GET /points/0xinvalid` returns 400
- [ ] `GET /points/{validAddress}` returns expected shape
- [ ] Daily cap: address with >10 swaps in single UTC day caps at 1000 swap-points for that day
- [ ] Finality buffer: swaps from latest 32 blocks are excluded